### PR TITLE
[Bugifx] check if model checkpoint exists before loading

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -516,12 +516,13 @@ def train_validate_test(gpu, args):
     # Log the number of parameters by layer
     count_parameters_by_layer(model.module)
 
-    # Load the model weights if --load-model argument is provided (using the DATA_PATH directory as the root)
+    # Load the model weights if the model_file exists (using the DATA_PATH directory as the root)
     # TODO: Process model loading in the get_setup function
-    if args.model_file:
+    checkpoint_path = os.path.join(config["DATA_PATH"], args.model_file),
+    if args.model_file and os.path.exists(checkpoint_path):
         load_model(
             trainer=Trainer,
-            checkpoint_path=os.path.join(config["DATA_PATH"], args.model_file),
+            checkpoint_path=checkpoint_path,
             rank=rank,
             from_checkpoint=args.from_checkpoint,
         )


### PR DESCRIPTION
# Description

It's impossible to train a model from scratch with the current trainer code. The code attempts to load the model checkpoint even when it doesn't exist, and there is no way to disable it (args.model_file is set by the code even if it's not given explicitly).

Specifically, the model file's existence is not checked and `load-model` argument check is not implemented in `/bin/main.py:518`:
https://github.com/microsoft/protnote/blob/2d69e4442206eb30114a44ea55de31192cee8067/bin/main.py#L519-L530

This PR updates the training logic to check if the chcekpoint path exists before loading it. 

PS: It may be useful to update docs and also add an `else` clause that logs something along the lines of `INFO: Could not find checkpoint {path}, training from scratch`